### PR TITLE
Handle oauth unauthorized errors

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,9 +1,9 @@
 class Account < ActiveRecord::Base
   def self.from_omniauth(auth)
     where(auth.slice(:provider, :uid)).first_or_initialize.tap do |account|
-      account.provider = auth.provider
-      account.uid = auth.uid
-      account.name = auth.info.business_name
+      account.provider  = auth.provider
+      account.uid       = auth.uid
+      account.name      = auth.info.business_name
 
       account.update_token(auth.credentials)
 
@@ -12,13 +12,20 @@ class Account < ActiveRecord::Base
   end
 
   def update_token(token)
-    self.oauth_access_token = token.token
-    self.oauth_refresh_token = token.refresh_token
-    self.oauth_expires_at = token.expires_at
+    self.oauth_access_token   = token.token
+    self.oauth_refresh_token  = token.refresh_token
+    self.oauth_expires_at     = token.expires_at
   end
 
   def update_token!(token)
     update_token(token)
+    save!
+  end
+
+  def clear_token!
+    self.oauth_access_token   = nil
+    self.oauth_refresh_token  = nil
+    self.oauth_expires_at     = nil
     save!
   end
 end


### PR DESCRIPTION
When this error happens, token info is cleared from the current_account,
the session account_id is cleared and user is redirected to sign in.
