### PR TITLE
Request authorization for given account id

### DIFF
--- a/lib/bookingsync/engine.rb
+++ b/lib/bookingsync/engine.rb
@@ -17,6 +17,8 @@ module BookingSync
                 verify: ENV['BOOKINGSYNC_VERIFY_SSL'] == 'true'
               }
             end
+            env['omniauth.strategy'].options[:authorize_params][:account_id] =
+              env['rack.session']['_bookingsync_account_id']
           }
       end
     end

--- a/lib/bookingsync/engine/helpers.rb
+++ b/lib/bookingsync/engine/helpers.rb
@@ -2,11 +2,16 @@ module BookingSync::Engine::Helpers
   extend ActiveSupport::Concern
   # helper_method :current_account
   included do
+    before_action :store_bookingsync_account_id
     helper_method :current_account
     rescue_from OAuth2::Error, with: :handle_oauth_error
   end
 
   private
+
+  def store_bookingsync_account_id
+    session[:_bookingsync_account_id] = params.delete(:_bookingsync_account_id)
+  end
 
   def after_bookingsync_sign_in_path
     root_path


### PR DESCRIPTION
When the app is embedded, BookingSync adds the `_bookingsync_account_id`
parameter to each embed request. The Engine then uses this id to request
authorization and skip the account choice.
