### PR TITLE
Session can be authorized for multiple accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To get started, add the `bookingsync-engine` gem to your Gemfile.
 Then, generate a migration for the `Account` class:
 
 ```
-$ rails g migration CreateAccounts provider:string uid:integer name:string oauth_access_token:string oauth_refresh_token:string oauth_expires_at:string
+$ rails g migration CreateAccounts provider:string uid:integer:index name:string oauth_access_token:string oauth_refresh_token:string oauth_expires_at:string
 $ rake db:migrate
 ```
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,12 +2,12 @@ class SessionsController < ApplicationController
   def create
     auth = request.env["omniauth.auth"]
     account = ::Account.from_omniauth(auth)
-    session[:account_id] = account.id
+    account_id_authorized!(account.uid)
     redirect_to after_bookingsync_sign_in_path, notice: "Signed in!"
   end
 
   def destroy
-    session[:account_id] = nil
+    clear_account_id_authorization!
     redirect_to after_bookingsync_sign_out_path, notice: "Signed out"
   end
 end


### PR DESCRIPTION
When embedding requests a specific account id to be used, we now check
if this account has been already authorized, and if so, use it without
requesting authorization via oauth.
