### PR TITLE
Sign out inactive sesions in embedded apps

### DIFF
--- a/lib/bookingsync/engine.rb
+++ b/lib/bookingsync/engine.rb
@@ -35,6 +35,9 @@ module BookingSync
     cattr_accessor :embedded
     self.embedded = true
 
+    cattr_accessor :sign_out_after
+    self.sign_out_after = 10.minutes
+
     def self.embedded!
       self.embedded = true
     end


### PR DESCRIPTION
This way, when a user logs out from BookingSync, but doesn't close
the browser window, after a period of time defined in
BookingSync::Engine.sign_out_after (default 10 minutes), the session
will become invalid and the user will have to log in again.
