### PR TITLE
Handle BookingSync::API::Unauthorized

### DIFF
--- a/lib/bookingsync/engine/helpers.rb
+++ b/lib/bookingsync/engine/helpers.rb
@@ -4,6 +4,7 @@ module BookingSync::Engine::Helpers
     before_action :store_bookingsync_account_id, :enforce_account_id
     helper_method :current_account
     rescue_from OAuth2::Error, with: :handle_oauth_error
+    rescue_from BookingSync::API::Unauthorized, with: :reset_authorization!
   end
 
   private
@@ -22,14 +23,18 @@ module BookingSync::Engine::Helpers
 
   def handle_oauth_error(error)
     if error.code == "Not authorized"
-      if current_account
-        current_account.clear_token!
-        clear_account_id_authorization!
-        redirect_to "/auth/bookingsync"
-      end
+      current_account.try(:clear_token!)
+      reset_authorization!
     else
       raise
     end
+  end
+
+  def reset_authorization!
+    session[:_bookingsync_account_id] =
+      params[:account_id].presence || session[:account_id]
+    clear_account_id_authorization!
+    redirect_to "/auth/bookingsync"
   end
 
   def current_account


### PR DESCRIPTION
When this exception is caught, the session is reset, and new 
authorization is requested.
