### PR TITLE
Handle auth failure

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,4 +10,9 @@ class SessionsController < ApplicationController
     clear_account_id_authorization!
     redirect_to after_bookingsync_sign_out_path, notice: "Signed out"
   end
+
+  def failure
+    response.headers['X-Frame-Options'] = '' if BookingSync::Engine.embedded
+    @error_message = params[:message].humanize
+  end
 end

--- a/app/views/sessions/failure.html.erb
+++ b/app/views/sessions/failure.html.erb
@@ -1,0 +1,5 @@
+<h1>Authentication failed</h1>
+
+<p>Error: <%= @error_message %></p>
+
+<a href="/auth/bookingsync">Sign in again</a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   get '/auth/:provider/callback', to: 'sessions#create'
+  get '/auth/failure', to: 'sessions#failure'
   get '/signout' => 'sessions#destroy', as: :signout
 end


### PR DESCRIPTION
Adds a view and controller action for /auth/failure. This will
most likely be overridden in applications to match their style
and layout.
