### PR TITLE
Fix storing session cookies in safari iframe

### DIFF
--- a/app/views/sessions/safari_iframe_cookie_fix.html.erb
+++ b/app/views/sessions/safari_iframe_cookie_fix.html.erb
@@ -1,0 +1,4 @@
+<%= link_to "Sign in with BookingSync",
+      url_for(_bookingsync_account_id: bookingsync_account_id,
+        safari_iframe_cookie_fix: 1),
+      class: "btn btn-primary" %>

--- a/lib/bookingsync/engine/auth_helpers.rb
+++ b/lib/bookingsync/engine/auth_helpers.rb
@@ -85,14 +85,13 @@ module BookingSync::Engine::AuthHelpers
 
   # Requests authorization if not currently authorized.
   def authenticate_account!
-    store_bookingsync_account_id
+    store_bookingsync_account_id if BookingSync::Engine.embedded
     sign_out_if_inactive
     enforce_requested_account_authorized!
     request_authorization! unless current_account
   end
 
   def store_bookingsync_account_id # :nodoc:
-    return unless BookingSync::Engine.embedded
     session[:_bookingsync_account_id] = params.delete(:_bookingsync_account_id)
   end
 end

--- a/lib/bookingsync/engine/session_helpers.rb
+++ b/lib/bookingsync/engine/session_helpers.rb
@@ -1,6 +1,10 @@
 module BookingSync::Engine::SessionHelpers
   extend ActiveSupport::Concern
 
+  included do
+    before_filter :safari_iframe_cookie_fix, if: -> { BookingSync::Engine.embedded }
+  end
+
   private
 
   # Automatically resets authorization when the session goes inactive.
@@ -13,6 +17,25 @@ module BookingSync::Engine::SessionHelpers
 
     if last_visit && (Time.now.to_i - last_visit > BookingSync::Engine.sign_out_after)
       clear_authorization!
+    end
+  end
+
+  # Safari ignores cookies in iframes until the user clicks within them.
+  #
+  # This fix shows a button when the user first opens the app in an iframe,
+  # which tells safari to load the app's cookies. Then the normal OAuth
+  # process can continue.
+  def safari_iframe_cookie_fix
+    if request.user_agent =~ /Safari/
+      return if session[:safari_iframe_cookie_fixed]
+
+      if params[:safari_iframe_cookie_fix].present?
+        session[:safari_iframe_cookie_fixed] = true
+      else
+        allow_bookingsync_iframe
+        render "sessions/safari_iframe_cookie_fix", layout: "application",
+          locals: {bookingsync_account_id: params[:_bookingsync_account_id]}
+      end
     end
   end
 end


### PR DESCRIPTION
Safari doesn't accept any cookies from an iframe until the user clicks
within it. A workaround for that is to show a button on first load,
so that an interaction is required before the oauth process starts.
