### PR TITLE
Ensure files are included when use multiple inderdependent engines.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bookingsync-engine (0.4.4)
+    bookingsync-engine (0.4.5)
       bookingsync-api (>= 0.0.23)
       omniauth-bookingsync (~> 0.2.0)
       rails (>= 4.0.0)

--- a/lib/bookingsync/engine.rb
+++ b/lib/bookingsync/engine.rb
@@ -21,7 +21,7 @@ module BookingSync
       end
     end
 
-    initializer "bookingsync.controller_helper" do |app|
+    config.to_prepare do
       require "bookingsync/engine/helpers"
       require "bookingsync/engine/session_helpers"
       require "bookingsync/engine/auth_helpers"

--- a/lib/bookingsync/engine/version.rb
+++ b/lib/bookingsync/engine/version.rb
@@ -1,3 +1,3 @@
 module BookingSync
-  ENGINE_VERSION = "0.4.4"
+  ENGINE_VERSION = "0.4.5"
 end


### PR DESCRIPTION
In order to use engine-chain: `bookingsync-engine => bookingsync-application-engine => bookingsync-portalapplication-engine` we need to do that (after replacing `bookingsync-engine` with `bookingsync-application-engine` (in future will be replaced with `bookingsync-portalapplication-engine`) in https://github.com/BookingSync/bsa-holidaylettings/commit/4bd46b9d0713bfa0edf8033b5dd646de38788d9b#diff-8b7db4d5cc4b8f6dc8feb7030baa2478R41)