### PR TITLE
[WIP] Open new thread to force refresh token update

### DIFF
--- a/lib/bookingsync/engine/model.rb
+++ b/lib/bookingsync/engine/model.rb
@@ -62,8 +62,12 @@ module BookingSync::Engine::Model
   end
 
   def update_token!(token)
-    update_token(token)
-    save!
+    Thread.new do
+      ActiveRecord::Base.connection_pool.with_connection do
+        update_token(token)
+        save!
+      end
+    end.join
   end
 
   def clear_token!

--- a/lib/bookingsync/engine/model.rb
+++ b/lib/bookingsync/engine/model.rb
@@ -17,6 +17,7 @@ module BookingSync::Engine::Model
   end
 
   def token
+    Rails.logger.info("[refresh_token] Token requested (#{id})")
     @token ||= begin
       token_options = {}
       if oauth_refresh_token
@@ -28,15 +29,26 @@ module BookingSync::Engine::Model
         oauth_access_token, token_options)
 
       if token.expired?
+        Rails.logger.info("[refresh_token] Token expired, requesting a refresh... (#{id})")
         refresh_token!(token)
       else
+        Rails.logger.info("[refresh_token] Token still valid (#{id})")
         token
       end
     end
   end
 
   def refresh_token!(current_token = token)
-    @token = current_token.refresh!.tap { |new_token| update_token!(new_token) }
+    @token = current_token.refresh!.tap do |new_token|
+      Rails.logger.info("[refresh_token] Updating local token with refresh_token: #{new_token.refresh_token} (#{id})")
+      update_token!(new_token)
+
+      if read_attribute(:oauth_refresh_token) == new_token.refresh_token
+        Rails.logger.info("[refresh_token] Token update successful (#{id})")
+      else
+        Rails.logger.info("[refresh_token] Token update failed (#{id})")
+      end
+    end
   end
 
   def api

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -72,6 +72,8 @@ RSpec.describe Account, type: :model do
     end
 
     context "when the stored token is expired" do
+      self.use_transactional_fixtures = false
+
       let(:expires_at) { 1.day.ago.to_i.to_s }
       let(:new_expires_at) { 2.days.from_now.to_i.to_s }
       let(:token) { double(expired?: true, refresh!: double(token: "refreshed_token",
@@ -95,6 +97,10 @@ RSpec.describe Account, type: :model do
         expect(account.oauth_access_token).to eq("refreshed_token")
         expect(account.oauth_refresh_token).to eq("refreshed_refresh_token")
         expect(account.oauth_expires_at).to eq(new_expires_at)
+      end
+
+      after do
+        Account.destroy_all
       end
     end
   end


### PR DESCRIPTION
To write a proper test, we require the token refresh to happen within a trasnaction.
So far trying to use sqlite3 failed with `SQLite3::BusyException: database is locked:`
I have tried setting timeouts to db and monkeypatching connection with `:immediate` switch.

Sqlite docs states that by default it should support multithreading. 
It is possible though that our nested write simply cannot be done in sqlite, as the nested thread is waiting for the initial transaction to commit.
If that is the case, we will have to switch testing of this gem to postgresql.