### PR TITLE
remove transaction escaping from token update

### DIFF
--- a/lib/bookingsync/engine/model.rb
+++ b/lib/bookingsync/engine/model.rb
@@ -50,12 +50,8 @@ module BookingSync::Engine::Model
   end
 
   def update_token!(token)
-    Thread.new do
-      ActiveRecord::Base.connection_pool.with_connection do
-        update_token(token)
-        save!
-      end
-    end.join
+    update_token(token)
+    save!
   end
 
   def clear_token!

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -99,18 +99,6 @@ RSpec.describe Account, type: :model do
         expect(token).to receive(:refresh!)
         account.token
       end
-
-      it "stores the refreshed token even with rollback" do
-        Account.transaction do
-          account.token
-          raise ActiveRecord::Rollback
-        end
-
-        account.reload
-        expect(account.oauth_access_token).to eq("refreshed_token")
-        expect(account.oauth_refresh_token).to eq("refreshed_refresh_token")
-        expect(account.oauth_expires_at).to eq(new_expires_at)
-      end
     end
   end
 


### PR DESCRIPTION
This should fix the connection pool problems.