### PR TITLE
Fix broken app when `helper_method` is missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ before_script:
   - cp spec/dummy/config/database.yml.travis spec/dummy/config/database.yml
   - psql -c 'create database travis_ci_test;' -U postgres
 before_install:
-  - gem install bundler
-  - gem update bundler
+  - gem install bundler -v 1.15.1 --no-rdoc --no-ri
+  - bundle _1.15.1_ install
 rvm:
   - 2.2.5
   - 2.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Master
 
+* Fix `AuthHelpers` include when `helper_method` is missing
+
 # 2.0.2 (2017-06-14)
 
 * Make internal API of APIClient more flexible

--- a/lib/bookingsync/engine/auth_helpers.rb
+++ b/lib/bookingsync/engine/auth_helpers.rb
@@ -4,7 +4,9 @@ module BookingSync::Engine::AuthHelpers
   included do
     rescue_from OAuth2::Error, with: :handle_oauth_error
     rescue_from BookingSync::API::Unauthorized, with: :reset_authorization!
-    helper_method :current_account
+    if respond_to?(:helper_method)
+      helper_method :current_account
+    end
   end
 
   private


### PR DESCRIPTION
In Rails 5, `helper_method` was removed from `ActionController::API::Class`.
The module including `helper_method` is added to `ActionController` hence, when any dependencies rely on rails-api, the app breaks.