### PR TITLE
Fix broken app when `helper_method` is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Master
 
+* Fix `AuthHelpers` include when `helper_method` is missing
+
 # 4.0.0 (2019-04-24)
 
 * Add support for multi application setup

--- a/lib/bookingsync/engine/auth_helpers.rb
+++ b/lib/bookingsync/engine/auth_helpers.rb
@@ -4,7 +4,9 @@ module BookingSync::Engine::AuthHelpers
   included do
     rescue_from OAuth2::Error, with: :handle_oauth_error
     rescue_from BookingSync::API::Unauthorized, with: :reset_authorization!
-    helper_method :current_account
+    if respond_to?(:helper_method)
+      helper_method :current_account
+    end
   end
 
   private


### PR DESCRIPTION
In Rails 5, helper_method was removed from ActionController::API::Class.
The module including helper_method is added to ActionController hence, when any dependencies rely on rails-api, the app breaks.