### PR TITLE
Add retryable for refresh token timeouts, change defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Master
 
+* Add configuration for token refresh timeout and retry count
+
 # 5.0.0 (2020-04-01)
 
 * Add support for Rails 6.0

--- a/lib/bookingsync-engine.rb
+++ b/lib/bookingsync-engine.rb
@@ -8,6 +8,12 @@ module BookingSyncEngine
   cattr_accessor :multi_app_model
   self.multi_app_model = -> { ::Account }
 
+  cattr_accessor :oauth_client_connection_options
+  self.oauth_client_connection_options = { request: { timeout: 2 } }
+
+  cattr_accessor :token_refresh_timeout_retry_count
+  self.token_refresh_timeout_retry_count = 2
+
   def self.setup
     yield self
   end

--- a/lib/bookingsync/engine/retryable.rb
+++ b/lib/bookingsync/engine/retryable.rb
@@ -1,0 +1,16 @@
+class BookingSync::Engine::Retryable
+  def self.perform(times:, errors:, before_retry: ->(_error) {})
+    executed = 0
+    begin
+      executed += 1
+      yield
+    rescue *errors => error
+      if executed < times
+        before_retry.call(error)
+        retry
+      else
+        raise error
+      end
+    end
+  end
+end

--- a/spec/lib/bookingsync/engine/retryable_spec.rb
+++ b/spec/lib/bookingsync/engine/retryable_spec.rb
@@ -1,0 +1,81 @@
+require "spec_helper"
+
+RSpec.describe BookingSync::Engine::Retryable do
+  describe ".perform" do
+    let(:before_retry) do
+      Class.new do
+        attr_reader :called, :errors
+
+        def initialize
+          @called = 0
+          @errors = []
+        end
+
+        def call(error)
+          @called += 1
+          @errors << error
+        end
+      end.new
+    end
+
+    it "retries logic for given amount of times for given errors
+    and raises original error if the number is exceeded" do
+      times_executed = 0
+
+      expect {
+        BookingSync::Engine::Retryable.perform(times: 3, errors: [NotImplementedError]) do
+          times_executed += 1
+          raise NotImplementedError
+        end
+      }.to raise_error NotImplementedError
+
+      expect(times_executed).to eq 3
+    end
+
+    it "calls before_retry callback before every retry" do
+      expect {
+        BookingSync::Engine::Retryable.perform(times: 3, errors: [NotImplementedError], before_retry: before_retry) do
+          raise NotImplementedError
+        end
+      }.to raise_error NotImplementedError
+
+      expect(before_retry.called).to eq 2
+      expect(before_retry.errors.count).to eq 2
+      expect(before_retry.errors.uniq.first).to be_a NotImplementedError
+    end
+
+    it "does not retry for given amount of times if it succeeds before exceeding given number" do
+      times_executed = 0
+
+      BookingSync::Engine::Retryable.perform(times: 3, errors: [NotImplementedError]) do
+        times_executed += 1
+        raise NotImplementedError if times_executed < 2
+      end
+
+      expect(times_executed).to eq 2
+    end
+
+    it "does not retry if no error is raised" do
+      times_executed = 0
+
+      BookingSync::Engine::Retryable.perform(times: 3, errors: [NotImplementedError]) do
+        times_executed += 1
+      end
+
+      expect(times_executed).to eq 1
+    end
+
+    it "does not retry not whitelisted errors" do
+      times_executed = 0
+
+      expect {
+        BookingSync::Engine::Retryable.perform(times: 3, errors: [LocalJumpError]) do
+          times_executed += 1
+          raise NotImplementedError
+        end
+      }.to raise_error NotImplementedError
+
+      expect(times_executed).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
Happens that those requests to refresh token take too long so we need a way to properly set it up. 
This PR adds  two configs:
  - oauth_client_connection_options - hash of options to be passed to Faraday by OAuth::Client, the new default is lowered from default 60s to 2s
  -  token_refresh_timeout_retry_count - self-explanatory I think, it's just how many time we want to retry in case of getting timeout, new default is 2 (previously no retries)