### PR TITLE
Customize account uid name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Master
 
+* Add support for customization of account's bookingsync_id_key (`synced_id` is kept as default)
+
 # 5.1.0 (2020-04-01)
 
 * Add configuration for token refresh timeout and retry count

--- a/lib/bookingsync-engine.rb
+++ b/lib/bookingsync-engine.rb
@@ -14,6 +14,9 @@ module BookingSyncEngine
   cattr_accessor :token_refresh_timeout_retry_count
   self.token_refresh_timeout_retry_count = 2
 
+  cattr_accessor :bookingsync_id_key
+  self.bookingsync_id_key = :synced_id
+
   def self.setup
     yield self
   end

--- a/lib/bookingsync/engine/auth_helpers.rb
+++ b/lib/bookingsync/engine/auth_helpers.rb
@@ -16,7 +16,7 @@ module BookingSync::Engine::AuthHelpers
     return if session[:account_id].nil?
 
     @current_account ||=
-      ::BookingSyncEngine.account_model.find_by_host_and_synced_id(request.host, session[:account_id])
+      ::BookingSyncEngine.account_model.find_by_host_and_bookingsync_id_key(request.host, session[:account_id])
   end
 
   # Callback after account is authorized.
@@ -25,7 +25,7 @@ module BookingSync::Engine::AuthHelpers
   #
   # @param account [Account] the just authorized account
   def account_authorized(account)
-    session[:account_id] = account.synced_id.to_s
+    session[:account_id] = account.public_send(BookingSyncEngine.bookingsync_id_key).to_s
   end
 
   # Clear authorization if the account passed from the BookingSync app store

--- a/lib/bookingsync/engine/models/account.rb
+++ b/lib/bookingsync/engine/models/account.rb
@@ -23,7 +23,7 @@ module BookingSync::Engine::Models::Account
 
     # DEPRECATED: Please use find_by_host_and_bookingsync_id_key instead.
     def find_by_host_and_synced_id(_host, synced_id)
-      warn("DEPRECATED: find_by_host_and_synced_id is deprecated, use #find_by_host_and_bookingsync_id_key instead. It will be removed with the release of version 5 of this gem. Called from #{Gem.location_of_caller.join(":")}")
+      warn("DEPRECATED: find_by_host_and_synced_id is deprecated, use #find_by_host_and_bookingsync_id_key instead. It will be removed with the release of version 6 of this gem. Called from #{Gem.location_of_caller.join(":")}")
       find_by_host_and_bookingsync_id_key(nil, synced_id)
     end
   end

--- a/lib/bookingsync/engine/models/account.rb
+++ b/lib/bookingsync/engine/models/account.rb
@@ -3,12 +3,12 @@ module BookingSync::Engine::Models::Account
   include BookingSync::Engine::Models::BaseAccount
 
   included do
-    validates :synced_id, uniqueness: true
+    validates BookingSyncEngine.bookingsync_id_key, uniqueness: true
   end
 
   module ClassMethods
     def from_omniauth(auth, _host)
-      account = find_or_initialize_by(synced_id: auth.uid, provider: auth.provider)
+      account = find_or_initialize_by(BookingSyncEngine.bookingsync_id_key => auth.uid, provider: auth.provider)
 
       account.tap do |account|
         account.name = auth.info.business_name
@@ -17,8 +17,14 @@ module BookingSync::Engine::Models::Account
       end
     end
 
+    def find_by_host_and_bookingsync_id_key(_host, bookingsync_id)
+      find_by(BookingSyncEngine.bookingsync_id_key => bookingsync_id)
+    end
+
+    # DEPRECATED: Please use find_by_host_and_bookingsync_id_key instead.
     def find_by_host_and_synced_id(_host, synced_id)
-      find_by(synced_id: synced_id)
+      warn("DEPRECATED: find_by_host_and_synced_id is deprecated, use #find_by_host_and_bookingsync_id_key instead. It will be removed with the release of version 5 of this gem. Called from #{Gem.location_of_caller.join(":")}")
+      find_by_host_and_bookingsync_id_key(nil, synced_id)
     end
   end
 

--- a/lib/bookingsync/engine/models/multi_applications_account.rb
+++ b/lib/bookingsync/engine/models/multi_applications_account.rb
@@ -3,7 +3,7 @@ module BookingSync::Engine::Models::MultiApplicationsAccount
   include BookingSync::Engine::Models::BaseAccount
 
   included do
-    validates :synced_id, uniqueness: { scope: :host }
+    validates BookingSyncEngine.bookingsync_id_key, uniqueness: { scope: :host }
   end
 
   module ClassMethods
@@ -13,7 +13,7 @@ module BookingSync::Engine::Models::MultiApplicationsAccount
                              "multi application support"
       end
 
-      account = find_or_initialize_by(host: host, synced_id: auth.uid, provider: auth.provider)
+      account = find_or_initialize_by(host: host, provider: auth.provider, BookingSyncEngine.bookingsync_id_key => auth.uid)
 
       account.tap do |account|
         account.name = auth.info.business_name
@@ -22,8 +22,14 @@ module BookingSync::Engine::Models::MultiApplicationsAccount
       end
     end
 
+    def find_by_host_and_bookingsync_id_key(host, bookingsync_id)
+      find_by(host: host, BookingSyncEngine.bookingsync_id_key => bookingsync_id)
+    end
+
+    # DEPRECATED: Please use find_by_host_and_bookingsync_id_key instead.
     def find_by_host_and_synced_id(host, synced_id)
-      find_by(host: host, synced_id: synced_id)
+      warn("DEPRECATED: find_by_host_and_synced_id is deprecated, use #find_by_host_and_bookingsync_id_key instead. It will be removed with the release of version 5 of this gem. Called from #{Gem.location_of_caller.join(":")}")
+      find_by_host_and_bookingsync_id_key(host, synced_id)
     end
   end
 

--- a/spec/dummy/config/initializers/bookingsync-engine.rb
+++ b/spec/dummy/config/initializers/bookingsync-engine.rb
@@ -1,3 +1,11 @@
+# temporarily change default to make sure initializer override works great
+BookingSyncEngine.module_eval do
+  self.bookingsync_id_key = :customized_key
+end
+
+# and now override to fix breaking specs
 BookingSyncEngine.setup do |setup|
   setup.multi_app_model = -> { ::MultiApplicationsAccount }
+
+  setup.bookingsync_id_key = :synced_id
 end

--- a/spec/dummy/db/migrate/20190623220013_add_custom_booking_sync_key_id_to_accounts.rb
+++ b/spec/dummy/db/migrate/20190623220013_add_custom_booking_sync_key_id_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddCustomBookingSyncKeyIdToAccounts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :accounts, :customized_key, :integer
+  end
+end

--- a/spec/dummy/db/migrate/20190623220132_add_custom_booking_sync_key_id_to_multi_applications_accounts.rb
+++ b/spec/dummy/db/migrate/20190623220132_add_custom_booking_sync_key_id_to_multi_applications_accounts.rb
@@ -1,0 +1,5 @@
+class AddCustomBookingSyncKeyIdToMultiApplicationsAccounts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :multi_applications_accounts, :customized_key, :integer
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_30_063104) do
+ActiveRecord::Schema.define(version: 2019_06_23_220132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2018_11_30_063104) do
     t.string "oauth_access_token"
     t.string "oauth_refresh_token"
     t.string "oauth_expires_at"
+    t.integer "customized_key"
     t.index ["synced_id"], name: "index_accounts_on_synced_id"
   end
 
@@ -48,6 +49,7 @@ ActiveRecord::Schema.define(version: 2018_11_30_063104) do
     t.string "oauth_refresh_token"
     t.string "oauth_expires_at"
     t.string "host", null: false
+    t.integer "customized_key"
     t.index ["host", "synced_id"], name: "index_multi_applications_accounts_on_host_and_synced_id", unique: true
     t.index ["host"], name: "index_multi_applications_accounts_on_host"
     t.index ["synced_id"], name: "index_multi_applications_accounts_on_synced_id"

--- a/spec/fixtures/accounts.yml
+++ b/spec/fixtures/accounts.yml
@@ -7,6 +7,7 @@ one:
   oauth_access_token: MyString
   oauth_refresh_token: MyString
   oauth_expires_at: MyString
+  customized_key: 1
 
 two:
   provider: MyString
@@ -15,3 +16,4 @@ two:
   oauth_access_token: MyString
   oauth_refresh_token: MyString
   oauth_expires_at: MyString
+  customized_key: 1

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Account, type: :model do
     end
   end
 
-  # depecated
+  # deprecated
   describe ".find_by_host_and_synced_id" do
     let!(:account_1) { Account.create!(synced_id: 1) }
     let!(:account_2) { Account.create!(synced_id: 2) }

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Account, type: :model do
     end
   end
 
+  # depecated
   describe ".find_by_host_and_synced_id" do
     let!(:account_1) { Account.create!(synced_id: 1) }
     let!(:account_2) { Account.create!(synced_id: 2) }
@@ -74,6 +75,16 @@ RSpec.describe Account, type: :model do
 
     it "returns the right account" do
       expect(Account.find_by_host_and_synced_id("any_host", 3)).to eq account_3
+    end
+  end
+
+  describe ".find_by_host_and_bookingsync_id_key" do
+    let!(:account_1) { Account.create!(synced_id: 1) }
+    let!(:account_2) { Account.create!(synced_id: 2) }
+    let!(:account_3) { Account.create!(synced_id: 3) }
+
+    it "returns the right account" do
+      expect(Account.find_by_host_and_bookingsync_id_key("any_host", 3)).to eq account_3
     end
   end
 

--- a/spec/models/multi_application_account_spec.rb
+++ b/spec/models/multi_application_account_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe MultiApplicationsAccount, type: :model do
     end
   end
 
+  # deprecated
   describe ".find_by_host_and_synced_id" do
     let!(:account_1) { MultiApplicationsAccount.create!(synced_id: 1, host: "example.test") }
     let!(:account_2) { MultiApplicationsAccount.create!(synced_id: 2, host: "example.test") }
@@ -83,6 +84,17 @@ RSpec.describe MultiApplicationsAccount, type: :model do
 
     it "returns the right account" do
       expect(MultiApplicationsAccount.find_by_host_and_synced_id("example2.test", 1)).to eq account_3
+    end
+  end
+
+  describe ".find_by_host_and_bookingsync_id_key" do
+    let!(:account_1) { MultiApplicationsAccount.create!(synced_id: 1, host: "example.test") }
+    let!(:account_2) { MultiApplicationsAccount.create!(synced_id: 2, host: "example.test") }
+    let!(:account_3) { MultiApplicationsAccount.create!(synced_id: 1, host: "example2.test") }
+    let!(:account_4) { MultiApplicationsAccount.create!(synced_id: 2, host: "example2.test") }
+
+    it "returns the right account" do
+      expect(MultiApplicationsAccount.find_by_host_and_bookingsync_id_key("example2.test", 1)).to eq account_3
     end
   end
 


### PR DESCRIPTION
Makes it possible to decouple from `synced_id` model attribute. After the PR all these account finder methods may start using any possible column which stores account id from Core