### PR TITLE
Allow to specify iframe redirect option

### DIFF
--- a/lib/bookingsync/engine.rb
+++ b/lib/bookingsync/engine.rb
@@ -10,6 +10,7 @@ module BookingSync
           ::BookingSyncEngine.support_multi_applications? ? nil : ENV["BOOKINGSYNC_APP_ID"],
           ::BookingSyncEngine.support_multi_applications? ? nil : ENV["BOOKINGSYNC_APP_SECRET"],
           scope: ENV["BOOKINGSYNC_SCOPE"],
+          iframe: ENV.fetch("BOOKINGSYNC_IFRAME", false),
           setup: -> (env) {
             if url = ENV["BOOKINGSYNC_URL"]
               env["omniauth.strategy"].options[:client_options].site = url


### PR DESCRIPTION
Omniauth provides an ability to handle redirects for iframe apps:  https://github.com/omniauth/omniauth/blob/7e1b49fc665827dcbc8fde12aa624357968a4f6a/lib/omniauth/strategy.rb#L517

Not sure why it started to happen after 6.0.0 release though. I found only this issue: https://github.com/omniauth/omniauth/issues/997